### PR TITLE
Fix: LogsVercel Prettier-Plugin-Tailwinds

### DIFF
--- a/Vercel.json
+++ b/Vercel.json
@@ -1,0 +1,18 @@
+{
+    "routes": [
+      {
+        "src": "/build/(.*)",
+        "dest": "/public/build/$1",
+        "headers": {
+          "Cache-Control": "public, max-age=31536000, immutable"
+        }
+      },
+      {
+        "src": "/(.*)",
+        "dest": "/public/index.php",
+        "headers": {
+          "Content-Type": "text/html; charset=utf-8"
+        }
+      }
+    ]
+  }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
                 "postcss": "^8.4.49",
                 "prettier": "^3.3.0",
                 "prettier-plugin-organize-imports": "^4.0.0",
-                "prettier-plugin-tailwindcss": "^0.6.5",
+                "prettier-plugin-tailwindcss": "^0.6.10",
                 "tailwindcss": "^3.4.17",
                 "vite": "^6.0",
                 "vue": "^3.4.0"
@@ -3576,9 +3576,9 @@
             }
         },
         "node_modules/prettier-plugin-tailwindcss": {
-            "version": "0.6.9",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.9.tgz",
-            "integrity": "sha512-r0i3uhaZAXYP0At5xGfJH876W3HHGHDp+LCRUJrs57PBeQ6mYHMwr25KH8NPX44F2yGTvdnH7OqCshlQx183Eg==",
+            "version": "0.6.10",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.6.10.tgz",
+            "integrity": "sha512-ndj2WLDaMzACnr1gAYZiZZLs5ZdOeBYgOsbBmHj3nvW/6q8h8PymsXiEnKvj/9qgCCAoHyvLOisoQdIcsDvIgw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3589,7 +3589,7 @@
                 "@prettier/plugin-pug": "*",
                 "@shopify/prettier-plugin-liquid": "*",
                 "@trivago/prettier-plugin-sort-imports": "*",
-                "@zackad/prettier-plugin-twig-melody": "*",
+                "@zackad/prettier-plugin-twig": "*",
                 "prettier": "^3.0",
                 "prettier-plugin-astro": "*",
                 "prettier-plugin-css-order": "*",
@@ -3616,7 +3616,7 @@
                 "@trivago/prettier-plugin-sort-imports": {
                     "optional": true
                 },
-                "@zackad/prettier-plugin-twig-melody": {
+                "@zackad/prettier-plugin-twig": {
                     "optional": true
                 },
                 "prettier-plugin-astro": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "postcss": "^8.4.49",
         "prettier": "^3.3.0",
         "prettier-plugin-organize-imports": "^4.0.0",
-        "prettier-plugin-tailwindcss": "^0. 6.5",
+        "prettier-plugin-tailwindcss": "^0.6.10",
         "tailwindcss": "^3.4.17",
         "vite": "^6.0",
         "vue": "^3.4.0"

--- a/vite.config.js
+++ b/vite.config.js
@@ -17,6 +17,9 @@ export default defineConfig({
             },
         }),
     ],
+    build: {
+        OutDir: 'public/build',
+    },
     resolve: {
         alias: {
             '@': '/resources/js',


### PR DESCRIPTION

This pull request includes a minor update to the `package.json` file. The change updates the version of the `prettier-plugin-tailwindcss` package to the latest version.

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L25-R25): Updated `prettier-plugin-tailwindcss` from version `^0.6.5` to `^0.6.10`.
* Fix.
